### PR TITLE
Add GitHub Actions workflow for Sphinx docs deployment to GitHub Pages

### DIFF
--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -23,6 +23,10 @@ jobs:
           source venv312/bin/activate
           pip install sphinx sphinx_rtd_theme myst-nb numpy scipy matplotlib numba joblib
 
+      - name: Create necessary directories
+        run: |
+          mkdir -p docs/devdocs
+          
       - name: Prepare documentation files
         run: |
           cp examples/tutorial.ipynb docs/userdocs/tutorial.ipynb

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -1,0 +1,49 @@
+name: Deploy Sphinx documentation to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'  # using Python 3.12 to match venv
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m venv venv312
+          source venv312/bin/activate
+          pip install sphinx sphinx_rtd_theme myst-nb numpy scipy matplotlib numba joblib
+
+      - name: Prepare documentation files
+        run: |
+          cp examples/tutorial.ipynb docs/userdocs/tutorial.ipynb
+          cp CHANGELOG.md docs/devdocs/changelog.md
+          cp CODE_OF_CONDUCT.md docs/devdocs/code_of_conduct.md
+          cp CONTRIBUTING.md docs/devdocs/contributing.md
+
+      - name: Generate API documentation
+        run: |
+          source venv312/bin/activate
+          sphinx-apidoc -f -o docs/apidocs src/crisprzip --separate
+
+      - name: Build documentation
+        run: |
+          source venv312/bin/activate
+          rm -rf docs/_build docs/jupyter_execute
+          sphinx-build docs docs/_build
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_build
+          force_orphan: true

--- a/.github/workflows/deploy-sphinx.yml
+++ b/.github/workflows/deploy-sphinx.yml
@@ -21,7 +21,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m venv venv312
           source venv312/bin/activate
-          pip install sphinx sphinx_rtd_theme myst-nb numpy scipy matplotlib numba joblib
+          pip install sphinx sphinx_rtd_theme myst-nb numpy scipy matplotlib numba joblib -e .
 
       - name: Create necessary directories
         run: |


### PR DESCRIPTION
This GitHub Actions workflow automates the process of building and deploying Sphinx documentation to GitHub Pages whenever changes are pushed to the main branch.

Workflow steps:

- Triggers on push to the main branch
- Sets up a Python 3.12 environment
- Installs necessary dependencies, including the project itself
- Prepares documentation files by copying relevant content (build_docs.sh)
- Generates API documentation
- Builds the Sphinx documentation
- Deploys the built documentation to GitHub Pages

I'm opening the PR to a feature branch. You can decide when to merge it to main.

After the merge, go to:

1. Your repository's "Settings" page
2. In the left sidebar, click on "Pages" under the "Code and automation" section
3. Under "Source", select "Deploy from a branch"
4. In the "Branch" section, choose the "gh-pages" branch
5. Select "/ (root)"
6. Save
7. Your documentation will be deployed at - https://hiddeoff.github.io/crisprzip