### PR TITLE
Add cross-platform compatibility and test workflow

### DIFF
--- a/.github/workflows/compatibility-test.yml
+++ b/.github/workflows/compatibility-test.yml
@@ -1,0 +1,48 @@
+name: Cross-platform compatibility and test execution
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: ['3.10', '3.11', '3.12']
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Create virtual environment
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
+          python -m venv venv${PYTHON_SANITIZED}
+      - name: Install dependencies and tests
+        shell: bash
+        run: |
+          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            source venv${PYTHON_SANITIZED}/Scripts/activate
+          else
+            source venv${PYTHON_SANITIZED}/bin/activate
+          fi
+          pip install -e ".[tests]"
+
+      - name: Run specific tests
+        shell: bash
+        run: |
+          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
+          if [[ "${{ runner.os }}" == "Windows" ]]; then
+            source venv${PYTHON_SANITIZED}/Scripts/activate
+          else
+            source venv${PYTHON_SANITIZED}/bin/activate
+          fi
+          pytest tests/cleavage_binding_prediction/test_cleavage_binding_prediction.py -v


### PR DESCRIPTION
I propose adding a GitHub Actions workflow for Python matrix testing. What it does is that it ensures CRISPRzip is compatible across multiple operating systems (latest versions of Ubuntu, Windows, and macOS) and your listed compatible Python versions (3.10, 3.11, and 3.12). The workflow installs CRISPRzip and its dependencies as defined in the `pyproject.toml `file, verifying that the project can be installed and its dependencies resolved across different environments. This helps to identify platform-specific or Python version-specific issues early as the project matures or time passes by.

What it solves?:

- Basic _does it install_ checks across platforms
- Catches missing OS level dependencies
- verifies `pyproject.toml` completness


This would look like:

```
name: Python matrix test

on:
  workflow_dispatch:

jobs:
  compatibility_test:
    strategy:
      matrix:
        os: [ubuntu-latest, windows-latest, macos-latest]
        python-version: ['3.10', '3.11', '3.12']       
    runs-on: ${{ matrix.os }}
    steps:
      - uses: actions/checkout@v4
      - name: Set up Python ${{ matrix.python-version }}
        uses: actions/setup-python@v4
        with:
          python-version: ${{ matrix.python-version }}
      - name: Install dependencies
        run: |
          python -m pip install --upgrade pip
          pip install .
```

Additionally, adding the test execution:

```
name: Cross-platform compatibility and test execution

on:
  workflow_dispatch:

jobs:
  test:
    strategy:
      matrix:
        os: [ubuntu-latest, windows-latest, macos-latest]
        python-version: ['3.10', '3.11', '3.12']
      fail-fast: false
    runs-on: ${{ matrix.os }}
    steps:
      - name: Checkout code
        uses: actions/checkout@v4

      - name: Set up Python ${{ matrix.python-version }}
        uses: actions/setup-python@v4
        with:
          python-version: ${{ matrix.python-version }}
      - name: Create virtual environment
        shell: bash
        run: |
          python -m pip install --upgrade pip
          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
          python -m venv venv${PYTHON_SANITIZED}
      - name: Install dependencies and tests
        shell: bash
        run: |
          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
          if [[ "${{ runner.os }}" == "Windows" ]]; then
            source venv${PYTHON_SANITIZED}/Scripts/activate
          else
            source venv${PYTHON_SANITIZED}/bin/activate
          fi
          pip install -e ".[tests]"

      - name: Run specific tests
        shell: bash
        run: |
          PYTHON_SANITIZED=$(echo "${{ matrix.python-version }}" | tr -d .)
          if [[ "${{ runner.os }}" == "Windows" ]]; then
            source venv${PYTHON_SANITIZED}/Scripts/activate
          else
            source venv${PYTHON_SANITIZED}/bin/activate
          fi
          pytest tests/cleavage_binding_prediction/test_cleavage_binding_prediction.py -v
```   


This workflow now combines the matrix with test execution and:

- Forces bash shell (GitHub Actions defaults to PowerShell on Windows)
- Creates venvs with sanitized Python versions (3.10 → 310 to prevent path issues)
- Test dependency resolution via `[tests]` extra
- Installation verification through `-e` flag
- Runs the cleavage binding prediction tests
- Handles OS-specific path differences

Currently proposing to just have a manual trigger, but this can be later changed to a push on `main` for example, if you prefer.